### PR TITLE
Fix exception on writing Last COM Port setting to ASCOM profile

### DIFF
--- a/ASCOM_Driver/FocuserDriver.cs
+++ b/ASCOM_Driver/FocuserDriver.cs
@@ -234,7 +234,7 @@ namespace ASCOM.DarkSkyGeek
 
                     Debug.Assert(objSerial == null);
 
-                    using (Profile driverProfile = new Profile())
+                    using (Profile driverProfile = new Profile() { DeviceType = "Focuser" })
                     {
                         Serial serial = null;
 
@@ -242,8 +242,6 @@ namespace ASCOM.DarkSkyGeek
 
                         if (autoDetectComPort)
                         {
-                            driverProfile.DeviceType = "Focuser";
-
                             // See if the last successfully connected COM port can be used first...
                             // This is a performance optimization that significantly reduces the time it takes to connect!
                             string lastComPort = driverProfile.GetValue(driverID, lastComPortProfileName, string.Empty, string.Empty);


### PR DESCRIPTION
Hey! I've been building my own OAG focuser according to your documentation here. I noticed that if auto-detecting the COM port is off in the focuser application, connection always fails.

I was able to trace it back to the call `driverProfile.WriteValue(driverID, lastComPortProfileName, serial.PortName)` on row 286 of `FocuserDriver.cs` throwing an exception. This seems to happen because the device type of the ASCOM profile object is by default "Telescope". The device type was being set inside an "if" clause in the code, meaning it was never being set in the non-auto-detecting case. Setting the type to "Focuser" earlier fixes the issue.

The device type seems to be properly set in every other place where data is being written to the profile.